### PR TITLE
Solve `jobs` output inconsistencies...

### DIFF
--- a/templates/foreman/master.pill.erb
+++ b/templates/foreman/master.pill.erb
@@ -69,10 +69,10 @@ show_status()
 <% engine.each_process do |name, process| -%>
 start_<%= name %>()
 {
-  su - $USERNAME <<EOS | cut -d ' ' -f 2 > $<%= name %>_pidfile
+  su - $USERNAME <<EOS > $<%= name %>_pidfile
   cd <%= engine.root %>
   <%= engine.environment.collect { |k,v| "#{k}=#{v} " }.join %><%= process.command %> > /dev/null 2>&1 &
-  jobs -l
+  echo \$!
 EOS
   log_end_msg $?
 }


### PR DESCRIPTION
...getting rid of it. :-)

When PID has 4 digits `jobs` outputs 2 spaces, and when PID has 5 digits `jobs` outputs 1 space, breaking the `cut` rule to get the PID.

I also saw that on Ubuntu 16.04, `jobs` outputs spaces before and after the '+' character. A future OS update will cause it to break again.

Ricardo Saffi help me out to solve this problem changing the way we get the PID. Instead to run `jobs -l` and cutting the output, we're simply echoing the environment variable $!.