### PR TITLE
Create PID dir on init script

### DIFF
--- a/templates/foreman/master.pill.erb
+++ b/templates/foreman/master.pill.erb
@@ -14,10 +14,11 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=<%= app %>
 USERNAME=<%= user %>
-mkdir -p /var/run/<%= app %>
 <% engine.each_process do |name, process| -%>
 <%= name %>_pidfile=/var/run/<%= app %>/<%= name %>.pid
 <% end -%>
+
+mkdir -p /var/run/<%= app %>
 
 [ -r /lib/lsb/init-functions ] &&. /lib/lsb/init-functions
 

--- a/templates/foreman/master.pill.erb
+++ b/templates/foreman/master.pill.erb
@@ -14,6 +14,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 NAME=<%= app %>
 USERNAME=<%= user %>
+mkdir -p /var/run/<%= app %>
 <% engine.each_process do |name, process| -%>
 <%= name %>_pidfile=/var/run/<%= app %>/<%= name %>.pid
 <% end -%>


### PR DESCRIPTION
Prevents extra configuration in server automation by creating the directory to store PID file