### PR TITLE
When Procfile is empty, doesn't generate init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Para gerar o pacote basta executar o seguinte comando:
   $ buildable build
 ```
 
+Quando o projeto não for um serviço, é possível desabilitar a criação do script de inicialização executando:
+
+```shell
+  $ buildable build --no-init
+```
+
 ### Via rake
 
 Para utilizar o _Buildable_ com o rake é necessário inluir o require no Rakefile
@@ -65,6 +71,12 @@ Para gerar o pacote basta executar
 
 ```shell
   $ bundle exec rake buildable:build
+```
+
+e para gerar o pacote sem script de inicialização
+
+```shell
+  $ bundle exec rake buildable:build -- --no-init
 ```
 
 _Para uma lista completa das tasks execute rake -D_

--- a/bin/buildable
+++ b/bin/buildable
@@ -1,7 +1,7 @@
 #!/bin/env ruby
 require 'buildable'
 
-case ARGV.join(' ')
+case ARGV.first
 when 'init'
   Buildable.init
 when 'build'

--- a/lib/buildable.rb
+++ b/lib/buildable.rb
@@ -26,7 +26,7 @@ module Buildable
     Recipe[:create_path]
     Recipe[:copy_source]
     Recipe[:vendor_gems]
-    Recipe[:make_init_script]
+    Recipe[:make_init_script] unless ARGV.include?('--no-init')
     Recipe[:make_package]
     Recipe[:remove_path]
   end

--- a/lib/buildable/recipes/build.rb
+++ b/lib/buildable/recipes/build.rb
@@ -26,8 +26,6 @@ module Buildable::Recipe
   end
 
   recipe :make_init_script do
-    next if File.zero?('Procfile')
-  
     # To make the initd script i'm using foreman's bluepill export with custom template
     puts "* Generating init scripts"
     params = {

--- a/lib/buildable/recipes/build.rb
+++ b/lib/buildable/recipes/build.rb
@@ -26,6 +26,8 @@ module Buildable::Recipe
   end
 
   recipe :make_init_script do
+    next if File.zero?('Procfile')
+  
     # To make the initd script i'm using foreman's bluepill export with custom template
     puts "* Generating init scripts"
     params = {


### PR DESCRIPTION
There are projects that doesn't need a init script because it isn't a service.